### PR TITLE
Move custom namespaces to this project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,21 @@
-# custom-clojure-ttt
+# Custom Tic Tac Toe in Clojure
 
-FIXME: description
+A program to play Tic Tac Toe, that depends on another project (https://github.com/bean00/Clojure-Tic-Tac-Toe). This is a customized version (Ex: playing with different board sizes). Has an option to play against a computer.
 
-## Installation
+## Instructions
+1. Clone or download this repository onto your local machine
+2. Use the console to run the program
+    - Make sure you have Leiningen installed (https://leiningen.org/)
+    - Run `lein run`
+3. Follow the program's instructions
+    - Single Player Mode: you vs. a computer
+    - Multi Player Mode: you vs. another person
 
-Download from http://example.com/FIXME.
+## Testing
+- Run `lein test` to run all the tests once
+- Run `lein test-refresh` to keep the tests running, and refresh the output anytime the code changes (need plugin below)
 
-## Usage
-
-FIXME: explanation
-
-    $ java -jar custom-clojure-ttt-0.1.0-standalone.jar [args]
-
-## Options
-
-FIXME: listing of options this app accepts.
-
-## Examples
-
-...
-
-### Bugs
-
-...
-
-### Any Other Sections
-### That You Think
-### Might be Useful
-
-## License
-
-Copyright © 2017 FIXME
-
-Distributed under the Eclipse Public License either version 1.0 or (at
-your option) any later version.
+## Plugins to Support Development
+- To be able to run `lein test-refresh`, include the `lein-test-refresh` plugin (https://github.com/jakemcc/lein-test-refresh)
+    - More information about declaring profiles: https://github.com/technomancy/leiningen/blob/master/doc/PROFILES.md#declaring-profiles
+- To have colorized and formatted output, include the `ultra` plugin (https://github.com/venantius/ultra)

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,12 @@
 (defproject custom-clojure-ttt "0.1.0-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
+  :description "Custom Tic Tac Toe written in Clojure"
+  :url "https://github.com/bean00/custom-clojure-ttt.git"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]]
-  :main ^:skip-aot custom-clojure-ttt.core
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.clojure/tools.namespace "0.2.11"]
+                 [clojure-tic-tac-toe "0.1.0-SNAPSHOT"]]
+  :profiles {:dev {:source-paths ["startup"]}
+             :uberjar {:aot :all}}
   :target-path "target/%s"
-  :profiles {:uberjar {:aot :all}})
+  :main ^:skip-aot custom-clojure-ttt.core)

--- a/src/custom_clojure_ttt/console_ui/console_ui.clj
+++ b/src/custom_clojure_ttt/console_ui/console_ui.clj
@@ -1,0 +1,56 @@
+(ns custom-clojure-ttt.console_ui.console_ui
+  (:require [custom-clojure-ttt.console_ui.console_ui_game_setup :as ui_game_setup]
+            [custom-clojure-ttt.console_ui.input_output :as io]
+            [clojure-tic-tac-toe.game_handler :as game_handler]))
+
+(defn- int-to-keyword
+  [number]
+  (keyword (str number)))
+
+(defn- get-side-length
+  [args]
+  (let [length (first args)]
+    (if-not (nil? length)
+      (int-to-keyword length)
+      :default-size)))
+
+(defn- create-initial-data
+  [side-length]
+  (let [game-mode (ui_game_setup/perform-setup)
+        valid-moves (ui_game_setup/get-valid-moves side-length)
+        winning-moves (ui_game_setup/get-winning-moves side-length)
+        move-strategies (ui_game_setup/decide-strategies game-mode)
+        create-view (ui_game_setup/get-create-view)
+        initial-data (game_handler/create-initial-data
+                       valid-moves winning-moves move-strategies create-view)]
+    initial-data))
+
+(defn- create-starting-game-state []
+  (game_handler/create-game-state game_handler/empty-board :X false))
+
+(defn- play-round
+  [game-state initial-data]
+  (let [get-move (game_handler/get-move-strategy game-state initial-data)
+        move (get-move game-state initial-data)
+        next-game-state (game_handler/add-move game-state initial-data move)
+        create-view (game_handler/get-create-view initial-data)]
+    (io/display-board next-game-state create-view)
+    next-game-state))
+
+(defn- play-all-rounds
+  [starting-game-state initial-data]
+  (loop [updated-game-state (play-round starting-game-state initial-data)]
+    (if (game_handler/finished? updated-game-state)
+      updated-game-state
+      (recur (play-round updated-game-state initial-data)))))
+
+(defn play-game [& args]
+  (let [side-length (get-side-length (flatten args))
+        initial-data (create-initial-data side-length)
+        starting-game-state (create-starting-game-state)
+        create-view (game_handler/get-create-view initial-data)
+        _ (ui_game_setup/display-instructions create-view)
+        final-game-state (play-all-rounds starting-game-state initial-data)
+        winner (game_handler/get-winner final-game-state initial-data)]
+   (io/display-game-over-message winner)))
+

--- a/src/custom_clojure_ttt/console_ui/console_ui.clj
+++ b/src/custom_clojure_ttt/console_ui/console_ui.clj
@@ -33,14 +33,14 @@
   (let [get-move (game_handler/get-move-strategy game-state initial-data)
         move (get-move game-state initial-data)
         next-game-state (game_handler/add-move game-state initial-data move)
-        create-view (game_handler/get-create-view initial-data)]
+        create-view (:create-view initial-data)]
     (io/display-board next-game-state create-view)
     next-game-state))
 
 (defn- play-all-rounds
   [starting-game-state initial-data]
   (loop [updated-game-state (play-round starting-game-state initial-data)]
-    (if (game_handler/finished? updated-game-state)
+    (if (:finished? updated-game-state)
       updated-game-state
       (recur (play-round updated-game-state initial-data)))))
 
@@ -48,7 +48,7 @@
   (let [side-length (get-side-length (flatten args))
         initial-data (create-initial-data side-length)
         starting-game-state (create-starting-game-state)
-        create-view (game_handler/get-create-view initial-data)
+        create-view (:create-view initial-data)
         _ (ui_game_setup/display-instructions create-view)
         final-game-state (play-all-rounds starting-game-state initial-data)
         winner (game_handler/get-winner final-game-state initial-data)]

--- a/src/custom_clojure_ttt/console_ui/console_ui.clj
+++ b/src/custom_clojure_ttt/console_ui/console_ui.clj
@@ -14,9 +14,11 @@
       (int-to-keyword length)
       :default-size)))
 
+
 (defn- create-initial-data
-  [side-length]
-  (let [game-mode (ui_game_setup/perform-setup)
+  [args]
+  (let [side-length (get-side-length (flatten args))
+        game-mode (ui_game_setup/perform-setup)
         valid-moves (ui_game_setup/get-valid-moves side-length)
         winning-moves (ui_game_setup/get-winning-moves side-length)
         move-strategies (ui_game_setup/decide-strategies game-mode)
@@ -25,16 +27,21 @@
                        valid-moves winning-moves move-strategies create-view)]
     initial-data))
 
+
 (defn- create-starting-game-state []
   (game_handler/create-game-state game_handler/empty-board :X false))
+
+
+(defn- display-board
+  [game-state {:keys [create-view]}]
+  (io/display-board game-state create-view))
 
 (defn- play-round
   [game-state initial-data]
   (let [get-move (game_handler/get-move-strategy game-state initial-data)
         move (get-move game-state initial-data)
         next-game-state (game_handler/add-move game-state initial-data move)
-        create-view (:create-view initial-data)]
-    (io/display-board next-game-state create-view)
+        _ (display-board next-game-state initial-data)]
     next-game-state))
 
 (defn- play-all-rounds
@@ -44,13 +51,21 @@
       updated-game-state
       (recur (play-round updated-game-state initial-data)))))
 
-(defn play-game [& args]
-  (let [side-length (get-side-length (flatten args))
-        initial-data (create-initial-data side-length)
+
+(defn- display-instructions
+  [{:keys [create-view]}]
+  (ui_game_setup/display-instructions create-view))
+
+(defn- display-game-over-message
+  [game-state {:keys [winning-moves]}]
+  (let [winner (game_handler/get-winner game-state winning-moves)]
+    (io/display-game-over-message winner)))
+
+(defn play-game
+  [& args]
+  (let [initial-data (create-initial-data args)
         starting-game-state (create-starting-game-state)
-        create-view (:create-view initial-data)
-        _ (ui_game_setup/display-instructions create-view)
+        _ (display-instructions initial-data)
         final-game-state (play-all-rounds starting-game-state initial-data)
-        winner (game_handler/get-winner final-game-state initial-data)]
-   (io/display-game-over-message winner)))
+        _ (display-game-over-message final-game-state initial-data)]))
 

--- a/src/custom_clojure_ttt/console_ui/console_ui_computer_move.clj
+++ b/src/custom_clojure_ttt/console_ui/console_ui_computer_move.clj
@@ -1,0 +1,9 @@
+(ns custom-clojure-ttt.console_ui.console_ui_computer_move
+  (:require [clojure-tic-tac-toe.computer_move :as computer_move]
+            [custom-clojure-ttt.console_ui.input_output :as io]))
+
+(defn have-computer-move
+  [game-state initial-data]
+  (io/display-computer-move-message)
+  (computer_move/make-minimax-move game-state initial-data))
+

--- a/src/custom_clojure_ttt/console_ui/console_ui_game_mode.clj
+++ b/src/custom_clojure_ttt/console_ui/console_ui_game_mode.clj
@@ -1,0 +1,15 @@
+(ns custom-clojure-ttt.console_ui.console_ui_game_mode
+  (:require [custom-clojure-ttt.console_ui.input_output :as io]))
+
+(def valid-game-modes #{:h :c})
+
+(defn- is-game-mode-invalid?
+  [game-mode]
+  (not (contains? valid-game-modes game-mode)))
+
+(defn get-valid-game-mode []
+  (loop [mode (io/get-initial-input)]
+    (if (is-game-mode-invalid? mode)
+      (recur (io/get-game-mode mode))
+      mode)))
+

--- a/src/custom_clojure_ttt/console_ui/console_ui_game_setup.clj
+++ b/src/custom_clojure_ttt/console_ui/console_ui_game_setup.clj
@@ -1,0 +1,55 @@
+(ns custom-clojure-ttt.console_ui.console_ui_game_setup
+  (:require [custom-clojure-ttt.console_ui.console_ui_computer_move :as ui_comp_move]
+            [custom-clojure-ttt.console_ui.console_ui_game_mode :as ui_game_mode]
+            [custom-clojure-ttt.console_ui.console_ui_human_move :as ui_human_move]
+            [custom-clojure-ttt.console_ui.input_output :as io]
+            [clojure-tic-tac-toe.game_handler :as game_handler]
+            [custom-clojure-ttt.valid_move_handler :as valid_move_handler]
+            [custom-clojure-ttt.view_handler :as view_handler]
+            [custom-clojure-ttt.winning_move_handler :as winning_move_handler]))
+
+(def game-mode-mapping
+  { :h :human,
+    :c :computer })
+
+(defn- convert-game-mode
+  [user-game-mode]
+  (user-game-mode game-mode-mapping))
+
+(defn perform-setup []
+  (io/display-introduction)
+  (io/display-game-mode-instructions)
+  (let [user-game-mode (ui_game_mode/get-valid-game-mode)
+        internal-game-mode (convert-game-mode user-game-mode)]
+    (io/display-result-of-game-mode-choice internal-game-mode)
+    internal-game-mode))
+
+
+(defn get-valid-moves
+  [side-length]
+  (valid_move_handler/get-valid-moves side-length))
+
+
+(defn get-winning-moves
+  [side-length]
+  (winning_move_handler/get-winning-moves side-length))
+
+
+(defn get-create-view []
+  view_handler/create-view)
+
+
+(defn display-instructions
+  [create-view]
+  (io/display-game-instructions)
+  (io/display-board game_handler/empty-board create-view))
+
+
+(defn decide-strategies
+  [game-mode]
+  (cond
+    (= game-mode :human)
+       {:X ui_human_move/get-human-move, :O ui_human_move/get-human-move}
+    (= game-mode :computer)
+       {:X ui_human_move/get-human-move, :O ui_comp_move/have-computer-move}))
+

--- a/src/custom_clojure_ttt/console_ui/console_ui_human_move.clj
+++ b/src/custom_clojure_ttt/console_ui/console_ui_human_move.clj
@@ -1,0 +1,16 @@
+(ns custom-clojure-ttt.console_ui.console_ui_human_move
+  (:require [custom-clojure-ttt.console_ui.input_output :as io]
+            [clojure-tic-tac-toe.game_handler :as game_handler]))
+
+(defn get-human-move
+  [game-state initial-data]
+  (let [player (game_handler/get-player game-state)]
+    (loop [move (io/get-move player)]
+      (cond
+        (game_handler/is-move-invalid? initial-data move)
+          (recur (io/get-move-if-move-is-invalid move player))
+        (game_handler/has-move-been-taken? game-state initial-data move)
+          (recur (io/get-move-if-move-was-taken move player))
+        :else
+          move))))
+

--- a/src/custom_clojure_ttt/console_ui/console_ui_human_move.clj
+++ b/src/custom_clojure_ttt/console_ui/console_ui_human_move.clj
@@ -5,7 +5,7 @@
 (defn get-human-move
   [game-state initial-data]
   (let [player (:player game-state)
-        valid-moves (:moves initial-data)]
+        valid-moves (:valid-moves initial-data)]
     (loop [move (io/get-move player)]
       (cond
         (game_handler/is-move-invalid? valid-moves move)

--- a/src/custom_clojure_ttt/console_ui/console_ui_human_move.clj
+++ b/src/custom_clojure_ttt/console_ui/console_ui_human_move.clj
@@ -4,12 +4,13 @@
 
 (defn get-human-move
   [game-state initial-data]
-  (let [player (:player game-state)]
+  (let [player (:player game-state)
+        valid-moves (:moves initial-data)]
     (loop [move (io/get-move player)]
       (cond
-        (game_handler/is-move-invalid? initial-data move)
+        (game_handler/is-move-invalid? valid-moves move)
           (recur (io/get-move-if-move-is-invalid move player))
-        (game_handler/has-move-been-taken? game-state initial-data move)
+        (game_handler/has-move-been-taken? game-state valid-moves move)
           (recur (io/get-move-if-move-was-taken move player))
         :else
           move))))

--- a/src/custom_clojure_ttt/console_ui/console_ui_human_move.clj
+++ b/src/custom_clojure_ttt/console_ui/console_ui_human_move.clj
@@ -4,7 +4,7 @@
 
 (defn get-human-move
   [game-state initial-data]
-  (let [player (game_handler/get-player game-state)]
+  (let [player (:player game-state)]
     (loop [move (io/get-move player)]
       (cond
         (game_handler/is-move-invalid? initial-data move)

--- a/src/custom_clojure_ttt/console_ui/input_output.clj
+++ b/src/custom_clojure_ttt/console_ui/input_output.clj
@@ -1,0 +1,107 @@
+(ns custom-clojure-ttt.console_ui.input_output
+  (:require [clojure.string :as str]
+            [clojure-tic-tac-toe.utilities :refer [join-lines]]
+            [custom-clojure-ttt.view_handler :as view]))
+
+(defn display-introduction []
+  (println "This is a Tic Tac Toe program.\n"))
+
+(defn display-game-mode-instructions []
+  (println (join-lines ["Please enter one of the following:"
+                        "- \"h\" to play another person"
+                        "- \"c\" to play against a computer\n"])))
+
+
+(defn- display-simple-prompt []
+  (print "> "))
+
+(defn- get-input []
+  (flush)
+  (keyword (str/trim (read-line))))
+
+(defn get-initial-input []
+  (display-simple-prompt)
+  (get-input))
+
+
+(defn- display-invalid-game-mode-message
+  [mode]
+  (printf "\n<!> Error: Game mode \"%s\" is invalid.", (name mode))
+  (printf " Must be a choice from above."))
+
+(defn- prompt-player-for-game-mode []
+  (printf "\nPlease enter the game mode: "))
+
+(defn get-game-mode
+  [mode]
+  (display-invalid-game-mode-message mode)
+  (prompt-player-for-game-mode)
+  (get-input))
+
+
+(defn- display-playing-person-message []
+  (println "\nOk, you chose to play another person."))
+
+(defn- display-playing-computer-message []
+  (println "\nOk, you chose to play a computer."))
+
+(defn display-result-of-game-mode-choice
+  [game-mode]
+  (cond
+    (= game-mode :human) (display-playing-person-message)
+    (= game-mode :computer) (display-playing-computer-message)))
+
+
+(defn display-game-instructions []
+  (println (join-lines ["\nTo enter a move, type a number."
+                        "It will be added to the board based on"
+                        "the following positions:\n"])))
+
+
+(defn- prompt-player-for-move
+  [player]
+  (printf "\nPlayer %s, please enter your move: ", (name player)))
+
+(defn get-move
+  [player]
+  (prompt-player-for-move player)
+  (get-input))
+
+
+(defn- display-invalid-move-message
+  [move]
+  (printf "\n<!> Error: Move \"%s\" is invalid. Must be from 1-9.", (name move)))
+
+(defn get-move-if-move-is-invalid
+  [move player]
+  (display-invalid-move-message move)
+  (get-move player))
+
+
+(defn- display-move-taken-message
+  [move]
+  (printf
+    "\n<!> Error: Move \"%s\" was already taken. Must move to an open position.",
+    (name move)))
+
+(defn get-move-if-move-was-taken
+  [move player]
+  (display-move-taken-message move)
+  (get-move player))
+
+
+(defn display-computer-move-message []
+  (println "\nThe computer moved."))
+
+
+(defn display-board
+  [game-state create-view]
+  (println (create-view game-state)))
+
+
+(defn display-game-over-message
+  [winner]
+  (if (contains? #{:X :O} winner)
+    (println (format "\nGame over. Player %s won." (name winner)))
+    (println "\nGame over. Ended in a tie.")))
+

--- a/src/custom_clojure_ttt/core.clj
+++ b/src/custom_clojure_ttt/core.clj
@@ -1,7 +1,9 @@
 (ns custom-clojure-ttt.core
+  (:require [custom-clojure-ttt.console_ui.console_ui :as console_ui])
   (:gen-class))
 
 (defn -main
-  "I don't do a whole lot ... yet."
+  "Custom Tic Tac Toe program."
   [& args]
-  (println "Hello, World!"))
+  (console_ui/play-game args))
+

--- a/src/custom_clojure_ttt/valid_move_handler.clj
+++ b/src/custom_clojure_ttt/valid_move_handler.clj
@@ -1,7 +1,11 @@
-(ns custom-clojure-ttt.valid_move_handler
-  (:require [clojure-tic-tac-toe.default_valid_moves :as default_valid_moves]))
+(ns custom-clojure-ttt.valid_move_handler)
+
+(def valid-moves
+  #{:1 :2 :3
+    :4 :5 :6
+    :7 :8 :9})
 
 (defn get-valid-moves
   [side-length]
-  default_valid_moves/valid-moves)
+  valid-moves)
 

--- a/src/custom_clojure_ttt/valid_move_handler.clj
+++ b/src/custom_clojure_ttt/valid_move_handler.clj
@@ -1,0 +1,7 @@
+(ns custom-clojure-ttt.valid_move_handler
+  (:require [clojure-tic-tac-toe.default_valid_moves :as default_valid_moves]))
+
+(defn get-valid-moves
+  [side-length]
+  default_valid_moves/valid-moves)
+

--- a/src/custom_clojure_ttt/view_handler.clj
+++ b/src/custom_clojure_ttt/view_handler.clj
@@ -1,0 +1,11 @@
+(ns custom-clojure-ttt.view_handler
+  (:require [clojure-tic-tac-toe.default_view :as default_view]
+            [clojure-tic-tac-toe.game_handler :as game_handler]
+            [clojure-tic-tac-toe.utilities :refer [join-lines]]))
+
+(def create-view
+  default_view/create-view)
+
+(defn get-create-view []
+  default_view/create-view)
+

--- a/src/custom_clojure_ttt/view_handler.clj
+++ b/src/custom_clojure_ttt/view_handler.clj
@@ -1,11 +1,27 @@
 (ns custom-clojure-ttt.view_handler
-  (:require [clojure-tic-tac-toe.default_view :as default_view]
-            [clojure-tic-tac-toe.game_handler :as game_handler]
+  (:require [clojure-tic-tac-toe.game_handler :as game_handler]
             [clojure-tic-tac-toe.utilities :refer [join-lines]]))
 
-(def create-view
-  default_view/create-view)
+(def tokens {:1 "1", :2 "2", :3 "3"
+             :4 "4", :5 "5", :6 "6"
+             :7 "7", :8 "8", :9 "9"
+             :X "X", :O "O"})
+
+(defn- create-row
+  [game-state token-key-1 token-key-2 token-key-3]
+  (format " %s | %s | %s ",
+          ((game_handler/token-at game-state token-key-1) tokens),
+          ((game_handler/token-at game-state token-key-2) tokens),
+          ((game_handler/token-at game-state token-key-3) tokens)))
+
+(defn create-view
+  [game-state]
+  (join-lines [(create-row game-state :1 :2 :3)
+               "---+---+---"
+               (create-row game-state :4 :5 :6)
+               "---+---+---"
+               (create-row game-state :7 :8 :9)]))
 
 (defn get-create-view []
-  default_view/create-view)
+  create-view)
 

--- a/src/custom_clojure_ttt/winning_move_handler.clj
+++ b/src/custom_clojure_ttt/winning_move_handler.clj
@@ -1,7 +1,23 @@
-(ns custom-clojure-ttt.winning_move_handler
-  (:require [clojure-tic-tac-toe.default_winning_moves :as default_winning_moves]))
+(ns custom-clojure-ttt.winning_move_handler)
+
+(def winning-rows
+  (list #{:1 :2 :3}
+        #{:4 :5 :6}
+        #{:7 :8 :9}))
+
+(def winning-columns
+  (list #{:1 :4 :7}
+        #{:2 :5 :8}
+        #{:3 :6 :9}))
+
+(def winning-diagonals
+  (list #{:1 :5 :9}
+        #{:3 :5 :7}))
+
+(def winning-moves
+  (concat winning-rows winning-columns winning-diagonals))
 
 (defn get-winning-moves
   [side-length]
-  default_winning_moves/winning-moves)
+  winning-moves)
 

--- a/src/custom_clojure_ttt/winning_move_handler.clj
+++ b/src/custom_clojure_ttt/winning_move_handler.clj
@@ -1,0 +1,7 @@
+(ns custom-clojure-ttt.winning_move_handler
+  (:require [clojure-tic-tac-toe.default_winning_moves :as default_winning_moves]))
+
+(defn get-winning-moves
+  [side-length]
+  default_winning_moves/winning-moves)
+

--- a/startup/user.clj
+++ b/startup/user.clj
@@ -1,0 +1,6 @@
+(ns user
+  (:use [clojure.tools.namespace.repl :only [refresh]]))
+
+(defn rerun
+  []
+  (refresh))

--- a/test/custom_clojure_ttt/console_ui/console_ui_computer_move_test.clj
+++ b/test/custom_clojure_ttt/console_ui/console_ui_computer_move_test.clj
@@ -8,7 +8,7 @@
   (valid_move_handler/get-valid-moves :3))
 
 (def initial-data
-  {:moves valid-moves})
+  {:valid-moves valid-moves})
 
 (deftest have-computer-move-test
   (testing "when having the computer move"

--- a/test/custom_clojure_ttt/console_ui/console_ui_computer_move_test.clj
+++ b/test/custom_clojure_ttt/console_ui/console_ui_computer_move_test.clj
@@ -1,0 +1,29 @@
+(ns custom-clojure-ttt.console_ui.console_ui_computer_move_test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest testing is]]
+            [custom-clojure-ttt.console_ui.console_ui_computer_move :refer :all]
+            [custom-clojure-ttt.valid_move_handler :as valid_move_handler]))
+
+(def valid-moves
+  (valid_move_handler/get-valid-moves :3))
+
+(def initial-data
+  {:moves valid-moves})
+
+(deftest have-computer-move-test
+  (testing "when having the computer move"
+    (with-out-str
+      (is (= :3
+             (have-computer-move
+               {:board {:X #{:1 :2 :8 :6}, :O #{:4 :5 :7 :9}}, :player :X}
+               initial-data))
+          "it returns a move"))
+    (is (= true
+           (str/includes?
+             (with-out-str
+               (have-computer-move
+                 {:board {:X #{:1 :2 :8 :6}, :O #{:4 :5 :7 :9}}, :player :X}
+                 initial-data))
+             "computer moved"))
+        "it displays that the computer moved")))
+

--- a/test/custom_clojure_ttt/console_ui/console_ui_game_mode_test.clj
+++ b/test/custom_clojure_ttt/console_ui/console_ui_game_mode_test.clj
@@ -1,0 +1,34 @@
+(ns custom-clojure-ttt.console_ui.console_ui_game_mode_test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest testing is]]
+            [custom-clojure-ttt.console_ui.console_ui_game_mode :refer :all]))
+
+(deftest get-valid-game-mode-test
+  (testing "when initially getting the game mode"
+    (is (= true
+           (str/includes?
+             (with-out-str
+               (with-in-str "h\n"
+                 (get-valid-game-mode)))
+             ">"))
+        "it displays the angle bracket"))
+  (testing "when a valid game mode is entered"
+    (with-out-str
+      (is (= :h
+             (with-in-str "h\n"
+               (get-valid-game-mode)))
+          "it returns the game mode as a keyword")))
+  (testing "when an invalid mode is entered 2 times, followed by a valid mode"
+    (let [output (with-out-str
+                   (with-in-str "X\nX\nh\n"
+                     (get-valid-game-mode)))]
+      (is (= true
+             (str/includes? output "is invalid"))
+          "it displays the correct error message")
+      (is (= true
+             (str/includes? output "enter the game mode"))
+          "it displays the game mode prompt")
+      (is (= 2
+             (count (re-seq #"enter the game mode" output)))
+          "it displays the game mode prompt twice"))))
+

--- a/test/custom_clojure_ttt/console_ui/console_ui_game_setup_test.clj
+++ b/test/custom_clojure_ttt/console_ui/console_ui_game_setup_test.clj
@@ -1,0 +1,81 @@
+(ns custom-clojure-ttt.console_ui.console_ui_game_setup_test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest testing is]]
+            [clojure-tic-tac-toe.default_valid_moves :as default_valid_moves]
+            [clojure-tic-tac-toe.default_winning_moves :as default_winning_moves]
+            [custom-clojure-ttt.console_ui.console_ui_computer_move :as ui_comp_move]
+            [custom-clojure-ttt.console_ui.console_ui_human_move :as ui_human_move]
+            [custom-clojure-ttt.console_ui.console_ui_game_setup :refer :all]
+            [custom-clojure-ttt.view_handler :as view_handler]))
+
+(defn- perform-setup-output []
+  (with-out-str
+    (with-in-str "h\n"
+      (perform-setup))))
+
+(deftest perform-setup-test
+  (testing "when the player chooses to play another person"
+    (is (= true
+           (str/includes?
+             (perform-setup-output)
+             "Tic Tac Toe"))
+        "it displays the introduction")
+    (is (= true
+           (str/includes?
+             (perform-setup-output)
+             "\"h\" to play"))
+        "it displays the game mode instructions")
+    (is (= true
+           (str/includes?
+             (perform-setup-output)
+             "chose to play another person"))
+        "it displays the 'playing person' message")
+    (with-out-str
+      (is (= :human
+             (with-in-str "h\n"
+               (perform-setup)))
+          "it returns the internal keyword for playing a person"))))
+
+(deftest get-valid-moves-test
+  (testing "when a side length is passed in"
+    (is (= default_valid_moves/valid-moves
+           (get-valid-moves :3))
+        "it returns the valid moves")))
+
+(deftest get-winning-moves-test
+  (testing "when the function is called"
+    (is (= default_winning_moves/winning-moves
+           (get-winning-moves :3))
+        "it returns the winning moves")))
+
+(deftest get-create-view-test
+  (testing "when getting the create view function"
+    (is (= view_handler/create-view
+           (get-create-view))
+        "it returns the function")))
+
+(deftest display-instructions-test
+  (testing "when the game is set up"
+    (is (= true
+           (str/includes?
+             (with-out-str
+               (display-instructions view_handler/create-view))
+             "type a number"))
+        "it displays the instructions")
+    (is (= true
+           (str/includes?
+             (with-out-str
+               (display-instructions view_handler/create-view))
+             " 4 | 5 | 6 "))
+        "it displays the example board")))
+
+(deftest decide-strategies-test
+  (testing "when the game is Human vs. Human"
+    (is (= {:X ui_human_move/get-human-move, :O ui_human_move/get-human-move}
+           (decide-strategies :human))
+        "it returns the strategies for 2 human players"))
+  (testing "when the game is Human vs. Computer"
+    (is (= {:X ui_human_move/get-human-move, :O ui_comp_move/have-computer-move}
+           (decide-strategies :computer))
+        "it returns strategies for a human and a computer")))
+

--- a/test/custom_clojure_ttt/console_ui/console_ui_game_setup_test.clj
+++ b/test/custom_clojure_ttt/console_ui/console_ui_game_setup_test.clj
@@ -1,12 +1,12 @@
 (ns custom-clojure-ttt.console_ui.console_ui_game_setup_test
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest testing is]]
-            [clojure-tic-tac-toe.default_valid_moves :as default_valid_moves]
-            [clojure-tic-tac-toe.default_winning_moves :as default_winning_moves]
             [custom-clojure-ttt.console_ui.console_ui_computer_move :as ui_comp_move]
             [custom-clojure-ttt.console_ui.console_ui_human_move :as ui_human_move]
             [custom-clojure-ttt.console_ui.console_ui_game_setup :refer :all]
-            [custom-clojure-ttt.view_handler :as view_handler]))
+            [custom-clojure-ttt.valid_move_handler :as valid_move_handler]
+            [custom-clojure-ttt.view_handler :as view_handler]
+            [custom-clojure-ttt.winning_move_handler :as winning_move_handler]))
 
 (defn- perform-setup-output []
   (with-out-str
@@ -38,13 +38,13 @@
 
 (deftest get-valid-moves-test
   (testing "when a side length is passed in"
-    (is (= default_valid_moves/valid-moves
+    (is (= valid_move_handler/valid-moves
            (get-valid-moves :3))
         "it returns the valid moves")))
 
 (deftest get-winning-moves-test
   (testing "when the function is called"
-    (is (= default_winning_moves/winning-moves
+    (is (= winning_move_handler/winning-moves
            (get-winning-moves :3))
         "it returns the winning moves")))
 

--- a/test/custom_clojure_ttt/console_ui/console_ui_human_move_test.clj
+++ b/test/custom_clojure_ttt/console_ui/console_ui_human_move_test.clj
@@ -1,0 +1,51 @@
+(ns custom-clojure-ttt.console_ui.console_ui_human_move_test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest testing is]]
+            [clojure-tic-tac-toe.board :as board]
+            [custom-clojure-ttt.console_ui.console_ui_human_move :refer :all]
+            [custom-clojure-ttt.valid_move_handler :as valid_move_handler]))
+
+(def valid-moves
+  (valid_move_handler/get-valid-moves :3))
+
+(def empty-game-state
+  {:board board/empty-board, :player :X})
+
+(def initial-data
+  {:moves valid-moves})
+
+(deftest get-human-move-test
+  (testing "when initially getting the move from the player"
+    (is (= true
+           (str/includes?
+             (with-out-str
+               (with-in-str "1"
+                 (get-human-move empty-game-state initial-data)))
+             "Player X, please enter"))
+        "it displays the prompt"))
+  (testing "when a valid move is entered"
+    (with-out-str
+      (is (= :2
+             (with-in-str "2"
+               (get-human-move empty-game-state initial-data)))
+          "it returns the move as a keyword")))
+  (testing "when an invalid move is entered, followed by a valid move"
+    (let [output (with-out-str
+                   (with-in-str "x\n1"
+                     (get-human-move empty-game-state initial-data)))]
+      (is (= true
+             (str/includes? output "is invalid"))
+          "it displays the correct error message")
+      (is (= 2
+             (count (re-seq #"enter your move" output))))
+          "it displays the prompt twice"))
+  (testing "when a move is entered that has already been taken"
+    (is (= true
+           (str/includes?
+             (with-out-str
+               (with-in-str "3\n1"
+                 (get-human-move {:board {:X #{:3}, :O #{}}, :player :O}
+                                 initial-data)))
+             "already taken"))
+        "it displays the correct error message")))
+

--- a/test/custom_clojure_ttt/console_ui/console_ui_human_move_test.clj
+++ b/test/custom_clojure_ttt/console_ui/console_ui_human_move_test.clj
@@ -12,7 +12,7 @@
   {:board board/empty-board, :player :X})
 
 (def initial-data
-  {:moves valid-moves})
+  {:valid-moves valid-moves})
 
 (deftest get-human-move-test
   (testing "when initially getting the move from the player"

--- a/test/custom_clojure_ttt/console_ui/console_ui_test.clj
+++ b/test/custom_clojure_ttt/console_ui/console_ui_test.clj
@@ -1,0 +1,44 @@
+(ns custom-clojure-ttt.console_ui.console_ui_test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest testing is]]
+            [custom-clojure-ttt.console_ui.console_ui :refer :all]))
+
+(defn- play-game-output []
+  (with-out-str
+    (with-in-str "h\n1\n2\n5\n9\n6\n4\n3\n7\n8\n"
+      (play-game))))
+
+(deftest play-game-test
+  (testing "when a game is played that ends in a tie (H vs. H)"
+    (is (= true
+           (str/includes?
+             (play-game-output)
+             "chose to play another person"))
+        "it sets up the game")
+    (is (= true
+           (str/includes?
+             (play-game-output)
+             " X | O | X "))
+        "it displays the board with the moves made")
+    (is (= true
+           (str/includes?
+             (play-game-output)
+             "tie"))
+        "it displays that the game ended in a tie"))
+  (testing "when a player wins (H vs. H)"
+    (is (= true
+           (str/includes?
+             (with-out-str
+               (with-in-str "h\n1\n4\n2\n5\n3\n"
+                 (play-game)))
+             "won"))
+        "it displays that the player won"))
+  (testing "when passing in the side length"
+    (is (= true
+           (str/includes?
+             (with-out-str
+               (with-in-str "h\n1\n4\n2\n5\n3\n"
+                 (play-game 3)))
+             " O | O | 6 "))
+        "it displays the board with the moves made")))
+

--- a/test/custom_clojure_ttt/console_ui/input_output_test.clj
+++ b/test/custom_clojure_ttt/console_ui/input_output_test.clj
@@ -1,0 +1,170 @@
+(ns custom-clojure-ttt.console_ui.input_output_test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest testing is]]
+            [clojure-tic-tac-toe.utilities :refer [join-lines]]
+            [custom-clojure-ttt.console_ui.input_output :refer :all]
+            [custom-clojure-ttt.view_handler :as view_handler]))
+
+(deftest display-introduction-test
+  (testing "when the player starts the program"
+    (is (= "This is a Tic Tac Toe program.\n\n"
+           (with-out-str
+             (display-introduction)))
+        "it displays an introduction")))
+
+(deftest display-game-mode-instructions-test
+  (testing "when the player has seen the introduction"
+    (is (= (join-lines ["Please enter one of the following:"
+                        "- \"h\" to play another person"
+                        "- \"c\" to play against a computer\n\n"])
+           (with-out-str
+             (display-game-mode-instructions)))
+        "it displays the instructions for choosing the game mode")))
+
+(deftest get-initial-input-test
+  (testing "when getting the initial input from the user"
+    (is (= "> "
+           (with-out-str
+             (with-in-str "h\n"
+               (get-initial-input))))
+        "it displays a simple prompt")
+    (with-out-str
+      (is (= :h
+             (with-in-str "h\n"
+               (get-initial-input)))
+          "it returns the input as a keyword"))))
+
+(deftest get-game-mode-test
+  (testing "when getting the game mode"
+    (is (= true
+           (str/includes?
+             (with-out-str
+               (with-in-str "h\n"
+                 (get-game-mode :h)))
+             "is invalid"))
+        "it displays the invalid game mode message")
+    (is (= true
+           (str/includes?
+             (with-out-str
+               (with-in-str "h\n"
+                 (get-game-mode :h)))
+             "enter the game mode"))
+        "it prompts the player for the game mode")
+    (with-out-str
+      (is (= :c
+             (with-in-str "c\n"
+               (get-game-mode :h)))
+          "it returns the input as a keyword"))))
+
+(deftest display-result-of-game-mode-choice-test
+  (testing "when the player chooses to play another person"
+    (is (= true
+           (str/includes?
+             (with-out-str
+               (display-result-of-game-mode-choice :human))
+             "play another person"))
+        "it displays the 'playing person' message"))
+  (testing "when the player chooses to play a computer"
+    (is (= true
+           (str/includes?
+             (with-out-str
+               (display-result-of-game-mode-choice :computer))
+             "play a computer"))
+        "it displays the 'playing computer' message")))
+
+(deftest display-game-instructions-test
+  (testing "when the player has seen the introduction"
+    (is (= (join-lines ["\nTo enter a move, type a number."
+                        "It will be added to the board based on"
+                        "the following positions:\n\n"])
+           (with-out-str
+             (display-game-instructions)))
+        "it displays the instructions")))
+
+(deftest get-move-test
+  (testing "when getting the move from the user"
+    (is (= true
+           (str/includes?
+             (with-out-str
+               (with-in-str "3\n"
+                 (get-move :X)))
+             "enter your move"))
+        "it displays the move prompt")
+    (with-out-str
+      (is (= :3
+             (with-in-str "3\n"
+               (get-move :X)))
+          "it returns the input as a keyword"))))
+
+(deftest get-move-if-move-is-invalid-test
+  (testing "when getting a move after an invalid move was entered"
+    (is (= true
+           (str/includes?
+             (with-out-str
+               (with-in-str "5\n"
+                 (get-move-if-move-is-invalid :3 :X)))
+             "is invalid. Must be from"))
+        "it displays the 'invalid move' message")
+    (is (= true
+           (str/includes?
+             (with-out-str
+               (with-in-str "5\n"
+                 (get-move-if-move-is-invalid :3 :X)))
+             "enter your move"))
+        "it calls 'get-move'")))
+
+(deftest get-move-if-move-was-taken-test
+  (testing "when getting a move after the previous move was taken"
+    (is (= true
+           (str/includes?
+             (with-out-str
+               (with-in-str "5\n"
+                 (get-move-if-move-was-taken :3 :X)))
+             "was already taken. Must move"))
+        "it displays the 'move taken' message")
+    (is (= true
+           (str/includes?
+             (with-out-str
+               (with-in-str "5\n"
+                 (get-move-if-move-was-taken :3 :X)))
+             "enter your move"))
+        "it calls 'get-move'")))
+
+(deftest display-computer-move-message-test
+  (testing "when the computer moves"
+    (is (= "\nThe computer moved.\n"
+           (with-out-str
+             (display-computer-move-message)))
+        "it displays a message indicating the computer moved")))
+
+(deftest display-board-test
+  (testing "when a game state is passed in"
+    (let [view (join-lines [" X | 2 | X "
+                            "---+---+---"
+                            " 4 | O | 6 "
+                            "---+---+---"
+                            " 7 | 8 | 9 "
+                            ""])]
+      (is (= view
+             (with-out-str
+               (display-board {:board {:X #{:1 :3}, :O #{:5}}}
+                              view_handler/create-view)))
+          "it displays the board correctly"))))
+
+(deftest display-game-over-message-test
+  (testing "when the game ended in a tie"
+    (is (= "\nGame over. Ended in a tie.\n"
+           (with-out-str
+             (display-game-over-message false)))
+        "it displays the tie message"))
+  (testing "when Player X won"
+    (is (= "\nGame over. Player X won.\n"
+           (with-out-str
+             (display-game-over-message :X)))
+        "it displays a message saying X won"))
+  (testing "when Player O won"
+    (is (= "\nGame over. Player O won.\n"
+           (with-out-str
+             (display-game-over-message :O)))
+        "it displays a message saying O won")))
+

--- a/test/custom_clojure_ttt/core_test.clj
+++ b/test/custom_clojure_ttt/core_test.clj
@@ -1,7 +1,0 @@
-(ns custom-clojure-ttt.core-test
-  (:require [clojure.test :refer :all]
-            [custom-clojure-ttt.core :refer :all]))
-
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))

--- a/test/custom_clojure_ttt/valid_move_handler_test.clj
+++ b/test/custom_clojure_ttt/valid_move_handler_test.clj
@@ -1,10 +1,9 @@
 (ns custom-clojure-ttt.valid_move_handler_test
   (:require [clojure.test :refer [deftest testing is]]
-            [clojure-tic-tac-toe.default_valid_moves :as default_valid_moves]
             [custom-clojure-ttt.valid_move_handler :refer :all]))
 
 (def valid-moves-on-3x3
-  default_valid_moves/valid-moves)
+  valid-moves)
 
 (deftest get-valid-moves-test
   (testing "when choosing a side length of 3"

--- a/test/custom_clojure_ttt/valid_move_handler_test.clj
+++ b/test/custom_clojure_ttt/valid_move_handler_test.clj
@@ -1,0 +1,18 @@
+(ns custom-clojure-ttt.valid_move_handler_test
+  (:require [clojure.test :refer [deftest testing is]]
+            [clojure-tic-tac-toe.default_valid_moves :as default_valid_moves]
+            [custom-clojure-ttt.valid_move_handler :refer :all]))
+
+(def valid-moves-on-3x3
+  default_valid_moves/valid-moves)
+
+(deftest get-valid-moves-test
+  (testing "when choosing a side length of 3"
+    (is (= valid-moves-on-3x3
+           (get-valid-moves :3))
+        "it returns the valid moves for a 3x3 board"))
+  (testing "when choosing the default size"
+    (is (= valid-moves-on-3x3
+           (get-valid-moves :default-size))
+        "it returns the valid moves for a 3x3 board")))
+

--- a/test/custom_clojure_ttt/view_handler_test.clj
+++ b/test/custom_clojure_ttt/view_handler_test.clj
@@ -1,13 +1,32 @@
 (ns custom-clojure-ttt.view_handler_test
   (:require [clojure.test :refer [deftest testing is]]
-            [clojure-tic-tac-toe.default_view :as default_view]
             [clojure-tic-tac-toe.game_handler :as game_handler]
             [clojure-tic-tac-toe.utilities :refer [join-lines]]
             [custom-clojure-ttt.view_handler :refer :all]))
 
+(deftest create-view-test
+  (testing "when an empty board is passed in"
+    (let [view (join-lines [" 1 | 2 | 3 "
+                            "---+---+---"
+                            " 4 | 5 | 6 "
+                            "---+---+---"
+                            " 7 | 8 | 9 "])]
+      (is (= view
+             (create-view game_handler/empty-board))
+          "it returns the formatted string for the example board")))
+  (testing "when a game state with a board is passed in"
+    (let [view (join-lines [" X | 2 | X "
+                            "---+---+---"
+                            " 4 | O | 6 "
+                            "---+---+---"
+                            " 7 | 8 | 9 " ])]
+      (is (= view
+             (create-view {:board {:X #{:1 :3}, :O #{:5}}}))
+          "it returns the formatted string for the board"))))
+
 (deftest get-create-view-test
   (testing "when getting the create view function"
-    (is (= default_view/create-view
+    (is (= create-view
            (get-create-view))
         "it returns the function")))
 

--- a/test/custom_clojure_ttt/view_handler_test.clj
+++ b/test/custom_clojure_ttt/view_handler_test.clj
@@ -1,0 +1,13 @@
+(ns custom-clojure-ttt.view_handler_test
+  (:require [clojure.test :refer [deftest testing is]]
+            [clojure-tic-tac-toe.default_view :as default_view]
+            [clojure-tic-tac-toe.game_handler :as game_handler]
+            [clojure-tic-tac-toe.utilities :refer [join-lines]]
+            [custom-clojure-ttt.view_handler :refer :all]))
+
+(deftest get-create-view-test
+  (testing "when getting the create view function"
+    (is (= default_view/create-view
+           (get-create-view))
+        "it returns the function")))
+

--- a/test/custom_clojure_ttt/winning_move_handler_test.clj
+++ b/test/custom_clojure_ttt/winning_move_handler_test.clj
@@ -1,10 +1,9 @@
 (ns custom-clojure-ttt.winning_move_handler_test
   (:require [clojure.test :refer [deftest testing is]]
-            [clojure-tic-tac-toe.default_winning_moves :as default_winning_moves]
             [custom-clojure-ttt.winning_move_handler :refer :all]))
 
 (def winning-moves-on-3x3
-  default_winning_moves/winning-moves)
+  winning-moves)
 
 (deftest get-winning-moves-test
   (testing "when choosing a side length of 3"

--- a/test/custom_clojure_ttt/winning_move_handler_test.clj
+++ b/test/custom_clojure_ttt/winning_move_handler_test.clj
@@ -1,0 +1,18 @@
+(ns custom-clojure-ttt.winning_move_handler_test
+  (:require [clojure.test :refer [deftest testing is]]
+            [clojure-tic-tac-toe.default_winning_moves :as default_winning_moves]
+            [custom-clojure-ttt.winning_move_handler :refer :all]))
+
+(def winning-moves-on-3x3
+  default_winning_moves/winning-moves)
+
+(deftest get-winning-moves-test
+  (testing "when choosing a side length of 3"
+    (is (= winning-moves-on-3x3
+           (get-winning-moves :3))
+        "it returns the winning moves for a 3x3 board"))
+  (testing "when choosing the default size"
+    (is (= winning-moves-on-3x3
+           (get-winning-moves :default-size))
+        "it returns the winning moves for a 3x3 board")))
+


### PR DESCRIPTION
This custom-clojure-ttt repo (referred to as the "custom project") contains namespaces for customizing the game (based on side length, rules, etc.).

The Clojure-Tic-Tac-Toe repo (referred to as the "core project") contains the core namespaces for a TTT API (functions that don't change if the board size changes, for example).

*Note: I was able to remove `winner` from `game-state`. I also cleaned up a few other values from `game-state`, by putting them into `initial-data` instead. `initial-data` is for data that is created at the beginning, but remains constant throughout the program's run time (although the `initial-data` is needed during the game).